### PR TITLE
fix: asg rebuilding on launch config rebuild

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_autoscaling_group" "asg" {
-  name                      = aws_launch_configuration.conf.name
+  name                      = "${var.name}-accesstier-asg"
   launch_configuration      = aws_launch_configuration.conf.name
   max_size                  = 10
   min_size                  = var.min_instances

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,7 @@ resource "aws_autoscaling_group" "asg" {
 }
 
 resource "aws_launch_configuration" "conf" {
-  name_prefix     = "${var.name}-accesstier-conf"
+  name_prefix     = "${var.name}-accesstier-conf-"
   image_id        = data.aws_ami.ubuntu.id
   instance_type   = var.instance_type
   key_name        = var.ssh_key_name


### PR DESCRIPTION
We are converting our existing Netagent 1 access tier built using the AWS Ubuntu module to the new Netagent 2 version. We've noticed that the Auto Scaling group name is no longer `"${var.name_prefix}-accesstier-asg"`, but `aws_launch_configuration.conf.name`. This introduces a breaking change where anytime the AMI is updated, the launch template will be re-created, and subsequently the autoscaling group will be re-created. This does not seem intended, so I am proposing adjustments as follows:

1. (Required) Change `aws_autoscaling_group.asg.name` from `aws_launch_configuration.conf.name` to `"${var.name}-accesstier-asg"`
2. (Optional) Change `aws_launch_configuration.conf.name_prefix` from "${var.name}-accesstier-conf" back to "${var.name}-accesstier-conf-"

Only the first change is necessary, the second change seems to be a revision of the old naming standard, which may also not be intended.