### PR TITLE
Allow end-user to set the name of the Access Tier

### DIFF
--- a/banyan.tf
+++ b/banyan.tf
@@ -7,14 +7,18 @@ terraform {
   }
 }
 
+locals {
+  access_tier_name = var.access_tier_name != "" ? var.access_tier_name : var.name
+}
+
 resource "banyan_accesstier" "accesstier" {
-  name                    = var.name
+  name                    = local.access_tier_name
   address                 = aws_alb.nlb.dns_name
   cluster                 = var.cluster
   disable_snat            = var.disable_snat
   src_nat_cidr_range      = var.src_nat_cidr_range
   api_key_id              = banyan_api_key.accesstier.id
-  tunnel_private_domains   = var.tunnel_private_domains
+  tunnel_private_domains  = var.tunnel_private_domains
   tunnel_cidrs            = var.tunnel_cidrs
   console_log_level       = var.console_log_level
   file_log_level          = var.file_log_level
@@ -29,7 +33,7 @@ resource "banyan_accesstier" "accesstier" {
 }
 
 resource "banyan_api_key" "accesstier" {
-  name        = var.name
-  description = "API key for ${var.name} access tier"
+  name        = local.access_tier_name
+  description = "API key for ${local.access_tier_name} access tier"
   scope       = "access_tier"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,13 @@
 // Common Banyan Variables followed by cloud specific variables
 variable "name" {
   type        = string
-  description = "Name to use when registering this Access Tier with the Banyan command center"
+  description = "Name to use for resources created by this module"
+}
+
+variable "access_tier_name" {
+  type        = string
+  description = "Name to use when registering this Access Tier with the Banyan command center. Defaults to var.name if not set."
+  default     = ""
 }
 
 variable "banyan_host" {
@@ -65,43 +71,43 @@ variable "tunnel_port" {
 }
 
 variable "tunnel_private_domains" {
-  type = list(string)
+  type        = list(string)
   description = "Any internal domains that can only be resolved on your internal network’s private DNS"
   default     = null
 }
 
 variable "tunnel_cidrs" {
-  type = list(string)
+  type        = list(string)
   description = "Backend CIDR Ranges that correspond to the IP addresses in your private network(s)"
   default     = null
 }
 
 variable "console_log_level" {
-  type = string
+  type        = string
   description = "Controls verbosity of logs to console. Must be one of \"ERR\", \"WARN\", \"INFO\", \"DEBUG\""
   default     = null
 }
 
 variable "file_log_level" {
-  type = string
+  type        = string
   description = "Controls verbosity of logs to file. Must be one of \"ERR\", \"WARN\", \"INFO\", \"DEBUG\""
   default     = null
 }
 
 variable "file_log" {
-  type = bool
+  type        = bool
   description = "Whether to log to file or not"
   default     = null
 }
 
 variable "log_num" {
-  type = number
+  type        = number
   description = "For file logs: Number of files to use for log rotation"
   default     = null
 }
 
 variable "log_size" {
-  type = number
+  type        = number
   description = "For file logs: Size of each file for log rotation"
   default     = null
 }


### PR DESCRIPTION
Allow end-user to set the name of the Access Tier to a different value than the resources.

Currently the `var.name` can not be set to any value longer than 23 characters. 

This is because some resources created by this module concatenate `var.name` with other strings that can be as long as 9 chars and some of these resources can not have names longer than 32 characters.

This PR allows the end-user to specify a specific name for the Access Tier that is not limited in length, while retaining the default behavior of using `var.name` for the access tier name.