### PR TITLE
Add support for ALB metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,7 @@ resource "aws_autoscaling_group" "asg" {
   health_check_type         = "ELB"
   target_group_arns         = compact([join("", aws_lb_target_group.target80.*.arn), aws_lb_target_group.target443.arn, aws_lb_target_group.target8443.arn, aws_lb_target_group.target51820.arn])
   max_instance_lifetime     = var.max_instance_lifetime
+  enabled_metrics           = var.enabled_metrics
 
   dynamic "tag" {
     # do another merge for application specific tags if need-be

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,9 @@ variable "custom_user_data" {
   description = "Custom commands to append to the launch configuration initialization script"
   default     = []
 }
+
+variable "enabled_metrics" {
+  type        = list(string)
+  description = "List of metrics to collect"
+  default     = []
+}


### PR DESCRIPTION
We are looking to enable advanced metric collection on our Auto Scaling Groups. In order to support ALB-level metrics, we need to pass in `enabled_metrics` to the autoscaling group.