### PR TITLE
fix-for-ami-lock

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ resource "aws_autoscaling_group" "asg" {
 
 resource "aws_launch_configuration" "conf" {
   name_prefix     = "${var.name}-accesstier-conf-"
-  image_id        = data.aws_ami.ubuntu.id
+  image_id        = var.ami_id != "" ? var.ami_id : data.aws_ami.ubuntu.id
   instance_type   = var.instance_type
   key_name        = var.ssh_key_name
   security_groups = concat([aws_security_group.sg.id], var.member_security_groups)

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,9 @@ variable "custom_user_data" {
   description = "Custom commands to append to the launch configuration initialization script"
   default     = []
 }
+
+variable "ami_id" {
+  type        = string
+  description = "ID of a custom AMI to use when creating Access Tier instances (leave blank to use default)"
+  default     = ""
+}


### PR DESCRIPTION
This just gives a way for the user to lock in the ami for the accesstier instances. This functionality was available in the first accestier module but not in the latest