### PR TITLE
Use real access tier name in output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "name" {
-  value       = var.name
+  value       = banyan_accesstier.accesstier.name
   description = "Name to use when registering this Access Tier with the console"
 }
 


### PR DESCRIPTION
The access tier name may not correspond to `var.name` if overridden: https://github.com/banyansecurity/terraform-aws-banyan-accesstier2/blob/main/banyan.tf#L11 