### PR TITLE
Add port 9998 listener and target group for healthcheck

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,6 @@ resource "aws_lb_listener" "listener9998" {
   }
 }
 
-
 resource "aws_autoscaling_policy" "cpu_policy" {
   name                   = "${var.name}-cpu-scaling-policy"
   autoscaling_group_name = aws_autoscaling_group.asg.name

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_autoscaling_group" "asg" {
   vpc_zone_identifier       = var.private_subnet_ids
   health_check_grace_period = 300
   health_check_type         = "ELB"
-  target_group_arns         = compact([join("", aws_lb_target_group.target80.*.arn), aws_lb_target_group.target443.arn, aws_lb_target_group.target8443.arn, aws_lb_target_group.target51820.arn])
+  target_group_arns         = compact([join("", aws_lb_target_group.target80.*.arn), aws_lb_target_group.target443.arn, aws_lb_target_group.target8443.arn, aws_lb_target_group.target51820.arn, aws_lb_target_group.target9998.arn])
   max_instance_lifetime     = var.max_instance_lifetime
   enabled_metrics           = var.enabled_metrics
 
@@ -328,6 +328,37 @@ resource "aws_lb_listener" "listener51820" {
     target_group_arn = aws_lb_target_group.target51820.arn
   }
 }
+
+resource "aws_lb_target_group" "target9998" {
+  name     = "${var.name}-tg-9998"
+  vpc_id   = var.vpc_id
+  port     = 9998
+  protocol = "TCP"
+  stickiness {
+    enabled = var.sticky_sessions
+    type    = "source_ip"
+  }
+  health_check {
+    port                = 9998
+    protocol            = "HTTP"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = merge(local.tags, var.target_group_tags)
+}
+
+resource "aws_lb_listener" "listener9998" {
+  load_balancer_arn = aws_alb.nlb.arn
+  port              = 9998
+  protocol          = "TCP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target9998.arn
+  }
+}
+
 
 resource "aws_autoscaling_policy" "cpu_policy" {
   name                   = "${var.name}-cpu-scaling-policy"


### PR DESCRIPTION
#### Overview
This PR adds a port 9998 listener and target group for health checks to the Banyan repository's Terraform configuration. These enhancements are designed to improve network health monitoring and align with Banyan's infrastructure standards.

#### Changes Made
1. **AWS Load Balancer Target Group Configuration:**
   - Added a new AWS Load Balancer Target Group `aws_lb_target_group` named `target9998`.
   - Configured with TCP protocol on port 9998, aligned with Banyan's requirement for specific port management.
   - Stickiness and health check features are configured to ensure robustness and reliability.

2. **AWS Load Balancer Listener Configuration:**
   - Established `aws_lb_listener` for the Load Balancer, using the same TCP protocol on port 9998.
   - Default action set to forward traffic to the newly created Target Group.

#### Alignment with Banyan Documentation
- The configuration is designed in accordance with Banyan's Access Tier architecture, ensuring that the Access Tier functions effectively as a reverse proxy on specified ports, which is essential for managing traffic in a Zero Trust environment (Banyan Security Documentation).
- The health check on port 9998 is crucial for determining the Netagent's ability to service traffic, a key aspect of Banyan's Netagent capabilities (Banyan Security Documentation).

#### Intent and Impact
- The intention is to leverage Banyan's advanced security functionalities to protect our cloud-native deployments.


