### PR TITLE
Add ability to override the max number of instances to autoscale up to.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "aws_security_group" "sg" {
 resource "aws_autoscaling_group" "asg" {
   name                      = "${var.name}-accesstier-asg"
   launch_configuration      = aws_launch_configuration.conf.name
-  max_size                  = 10
+  max_size                  = var.max_instances
   min_size                  = var.min_instances
   desired_capacity          = var.min_instances
   vpc_zone_identifier       = var.private_subnet_ids

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,12 @@ variable "min_instances" {
   default     = 2
 }
 
+variable "max_instances" {
+  type        = number
+  description = "Maximum number of Access Tier instances to keep alive"
+  default     = 10
+}
+
 variable "iam_instance_profile" {
   type        = string
   description = "The name attribute of the IAM instance profile to associate with launched instances"


### PR DESCRIPTION
Keeps the default value of 10 instances, but allows users to override that value if desired.