### PR TITLE
Add ability to create an internal load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,8 +198,8 @@ resource "aws_launch_configuration" "conf" {
 resource "aws_alb" "nlb" {
   name                             = "${var.name}-nlb"
   load_balancer_type               = "network"
-  internal                         = false
-  subnets                          = var.public_subnet_ids
+  internal                         = var.lb_internal
+  subnets                          = var.lb_internal ? var.private_subnet_ids : var.public_subnet_ids
   enable_cross_zone_load_balancing = var.cross_zone_enabled
 
   tags = merge(local.tags, var.lb_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -144,12 +144,12 @@ variable "vpc_id" {
 
 variable "public_subnet_ids" {
   type        = list(string)
-  description = "IDs of the subnets where the load balancer should create endpoints"
+  description = "IDs of the subnets where the external load balancer should create endpoints"
 }
 
 variable "private_subnet_ids" {
   type        = list(string)
-  description = "IDs of the subnets where the Access Tier should create instances"
+  description = "IDs of the subnets where the internal load balancer should create endpoints and Access Tier should create instances"
 }
 
 variable "healthcheck_cidrs" {
@@ -198,6 +198,12 @@ variable "ssh_key_name" {
   type        = string
   description = "Name of an SSH key stored in AWS to allow management access"
   default     = ""
+}
+
+variable "lb_internal" {
+  type        = bool
+  description = "Create an internal load balancer rather than an external one"
+  default     = false
 }
 
 variable "cross_zone_enabled" {


### PR DESCRIPTION
Allow overriding the default setting to create an external load balancer and automatically create endpoints in the already specified private subnets if enabled.