### PR TITLE
Fix Instance Profile from causing infinite terraform plans

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,8 +158,11 @@ resource "aws_launch_template" "conft" {
   vpc_security_group_ids = concat([aws_security_group.sg.id], var.member_security_groups)
   ebs_optimized   = true
 
-  iam_instance_profile {
-    name = var.iam_instance_profile
+  dynamic "iam_instance_profile" {
+    for_each = var.iam_instance_profile != null ? [1] : []
+    content {
+      name = var.iam_instance_profile
+    }
   }
 
   block_device_mappings {


### PR DESCRIPTION
Currently `var.iam_instance_profile` is set to `null` by default, and if set to an actual IAM Instance Profile, there is no issue. If left as the default value because it is not required, then `terraform plan` will always see a new change to push even though the value is `null` and infinitely increment the launch template version with no other changes.

This PR changes `var.iam_instance_profile` to be dynamic and only included as part of the terraform code when populated with a value other than `null`, which fixes the issue.