### PR TITLE
Add ability to set Access Tier description

### DIFF
--- a/banyan.tf
+++ b/banyan.tf
@@ -13,6 +13,7 @@ locals {
 
 resource "banyan_accesstier" "accesstier" {
   name                    = local.access_tier_name
+  description             = var.access_tier_description
   address                 = aws_alb.nlb.dns_name
   cluster                 = var.cluster
   disable_snat            = var.disable_snat

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "access_tier_name" {
   default     = ""
 }
 
+variable "access_tier_description" {
+  type        = string
+  description = "Description to use when registering this Access Tier with the Banyan command center."
+  default     = ""
+}
+
 variable "banyan_host" {
   type        = string
   description = "URL to the Banyan API server"


### PR DESCRIPTION
Newer versions of the Banyan Terraform provider support the ability to set the description for an Access Tier, but the functionality is not currently available in this module.

This PR adds the ability to set the description for an Access Tier.