### PR TITLE
Add ability to do an Instance Refresh after a Launch Template update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_autoscaling_group" "asg" {
     for_each = var.enable_instance_refresh ? [1] : []
 
     content {
-      strategy = "RollingWithAdditionalBatch"
+      strategy = "Rolling"
       preferences {
         min_healthy_percentage = 100
         max_healthy_percentage = 200

--- a/main.tf
+++ b/main.tf
@@ -145,18 +145,32 @@ resource "aws_autoscaling_group" "asg" {
       propagate_at_launch = true
     }
   }
+
   lifecycle {
     create_before_destroy = true
+  }
+
+  dynamic "instance_refresh" {
+    for_each = var.enable_instance_refresh ? [1] : []
+
+    content {
+      strategy = "RollingWithAdditionalBatch"
+      preferences {
+        min_healthy_percentage = 100
+        max_healthy_percentage = 200
+        instance_warmup        = 300
+      }
+    }
   }
 }
 
 resource "aws_launch_template" "conft" {
-  name_prefix     = "${var.name}-accesstier${var.autoscaling_launch_label}-"
-  image_id        = var.ami_id != "" ? var.ami_id : data.aws_ami.ubuntu.id
-  instance_type   = var.instance_type
-  key_name        = var.ssh_key_name
+  name_prefix            = "${var.name}-accesstier${var.autoscaling_launch_label}-"
+  image_id               = var.ami_id != "" ? var.ami_id : data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
   vpc_security_group_ids = concat([aws_security_group.sg.id], var.member_security_groups)
-  ebs_optimized   = true
+  ebs_optimized          = true
 
   iam_instance_profile {
     name = var.iam_instance_profile

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_autoscaling_group" "asg" {
 
   launch_template {
     id      = aws_launch_template.conft.id
-    version = "$Latest"
+    version = aws_launch_template.conft.latest_version
   }
 
   instance_maintenance_policy {
@@ -156,9 +156,12 @@ resource "aws_autoscaling_group" "asg" {
     content {
       strategy = "Rolling"
       preferences {
-        min_healthy_percentage = 100
-        max_healthy_percentage = 200
-        instance_warmup        = 300
+        min_healthy_percentage       = 100
+        max_healthy_percentage       = 200
+        instance_warmup              = 300
+        scale_in_protected_instances = "Ignore"
+        skip_matching                = true
+        standby_instances            = "Ignore"
       }
     }
   }
@@ -186,7 +189,6 @@ resource "aws_launch_template" "conft" {
     http_tokens                 = var.http_tokens_imds_v2
     http_put_response_hop_limit = var.http_hop_limit_imds_v2
   }
-
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,7 @@ resource "aws_autoscaling_group" "asg" {
   }
 
   dynamic "instance_refresh" {
-    for_each = var.enable_instance_refresh ? [1] : []
+    for_each = var.instance_refresh ? [1] : []
 
     content {
       strategy = "Rolling"

--- a/variables.tf
+++ b/variables.tf
@@ -356,8 +356,8 @@ variable "enabled_metrics" {
   default     = []
 }
 
-variable "enable_instance_refresh" {
-  description = "Enable or disable instance refresh for Auto Scaling Group"
+variable "instance_refresh" {
+  description = "Enable an instance refresh to automatically trigger after a configuration template update"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -355,3 +355,9 @@ variable "enabled_metrics" {
   description = "List of metrics to collect"
   default     = []
 }
+
+variable "enable_instance_refresh" {
+  description = "Enable or disable instance refresh for Auto Scaling Group"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Currently a manual Instance Refresh must be performed inside of AWS after a Launch Template update. This prevents full automation of updates with Terraform.

This PR adds the ability to optionally perform an automatic Instance Refresh after a Launch Template update by setting the `enable_instance_refresh` boolean variable to `true`. By default, it's set to `false` to not impact any existing configurations.