### PR TITLE
Restore detailed monitoring by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,12 +167,15 @@ resource "aws_launch_template" "conft" {
     virtual_name = "ephemeral0"
   }
 
+  monitoring {
+    enabled = true
+  }
+
   metadata_options {
     http_endpoint               = var.http_endpoint_imds_v2
     http_tokens                 = var.http_tokens_imds_v2
     http_put_response_hop_limit = var.http_hop_limit_imds_v2
   }
-
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Launch Configurations have detailed monitoring for EC2 instances enabled by default, but Launch Templates do not, so this functionality was lost after the conversion. This impacts the response time for autoscaling of instances in the event of an EC2 failure.

Launch Configuration documentation:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration
![Screenshot 2025-04-23 at 08 36 29](https://github.com/user-attachments/assets/89cc5f8a-1981-4a83-8a55-7fedeb805839)

Launch Template documentation:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template
![Screenshot 2025-04-23 at 08 42 38](https://github.com/user-attachments/assets/9c5d862c-7217-4525-8fa7-61fe0da2bd0e)

This PR restores EC2 detailed monitoring to be on by default.