### PR TITLE
Add ability to encrypt EBS volume

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,8 +163,27 @@ resource "aws_launch_template" "conft" {
   }
 
   block_device_mappings {
-    device_name  = "/dev/sdc"
-    virtual_name = "ephemeral0"
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_type = "gp3"
+      volume_size = 10
+      encrypted = var.ebs_encrypted
+    }
+  }
+
+  dynamic "block_device_mappings" {
+    for_each = var.kms_key_arn != null ? [1] : []
+    content {
+      device_name = "/dev/sda1"
+
+      ebs {
+        volume_type = "gp3"
+        volume_size = 10
+        encrypted = var.ebs_encrypted
+        kms_key_id  = var.kms_key_arn
+      }
+    }
   }
 
   metadata_options {

--- a/variables.tf
+++ b/variables.tf
@@ -355,3 +355,15 @@ variable "enabled_metrics" {
   description = "List of metrics to collect"
   default     = []
 }
+
+variable "ebs_encrypted" {
+  description = "Enable encryption for EBS volume if required"
+  type        = bool
+  default     = false
+}
+
+variable "kms_key_arn" {
+  description = "ARN of KMS key used for encryption of EBS volume when enabled (leave blank to use the default AWS KMS key)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
The module is currently attempting to use an ephemeral instance store on `/dev/sdc` for storage which does not support encryption. Despite this attempt, the default `t3.medium` instance does not support this, so Terraform is silently ignoring the settings and provisioning the default 8 GB `gp2` EBS volume on `/dev/sda1` instead. This `gp2` volume is configured with a baseline of 30 IOPS, and can only burst up to 3000 IOPS by using CPU credits.

This PR adds the ability to enable encryption and specify a KMS key to encrypt it with, as well as updates the storage volume to utilize the newer and cheaper `gp3` EBS volume which comes with a baseline of 3000 IOPS and 125 MB/s of throughput. The volume is sized up to 10 GB from 8GB to ensure that there is adequate storage, but should still be cheaper.